### PR TITLE
adding 'credentials=true' due to CORS problem

### DIFF
--- a/src/main/java/com/movienerds/movieinfo/MovieinfoApplication.java
+++ b/src/main/java/com/movienerds/movieinfo/MovieinfoApplication.java
@@ -23,6 +23,7 @@ public class MovieinfoApplication {
 				registry.addMapping("/movies/**")
 						.allowedOrigins("http://54.180.152.93:9000","http://localhost:9000", "http://localhost:9001", "http://localhost:9002")
 						.allowedMethods("GET", "POST")
+						.allowCredentials(true)
 						.maxAge(3000);
 			}
 		};


### PR DESCRIPTION
- Reviewer: @justinjeong5 

- Summary to PR

- Set the 'Credentials' to 'true' in order to fix the CORS problem.
- 
![image](https://user-images.githubusercontent.com/86760744/148015763-fef0f694-3c31-40c1-9d40-c190c3fa52d1.png)


## CheckList

- [ ] Unit test coverage
- [ ] Documentation
- [X] Self reviewed
