### PR TITLE
004 database

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'mysql:mysql-connector-java'
 	compileOnly 'org.projectlombok:lombok'
 
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.3'
 	implementation 'mysql:mysql-connector-java'
 	compileOnly 'org.projectlombok:lombok'
 
@@ -31,4 +32,5 @@ dependencies {
 
 test {
 	useJUnitPlatform()
+	systemProperty 'jasypt.encryptor.password', findProperty("jasypt.encryptor.password")
 }

--- a/src/main/java/com/movienerds/movieinfo/JasyptConfig.java
+++ b/src/main/java/com/movienerds/movieinfo/JasyptConfig.java
@@ -1,0 +1,31 @@
+package com.movienerds.movieinfo;
+
+import org.jasypt.encryption.StringEncryptor;
+import org.jasypt.encryption.pbe.PooledPBEStringEncryptor;
+import org.jasypt.encryption.pbe.config.SimpleStringPBEConfig;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JasyptConfig {
+
+    @Value("${jasypt.encryptor.password}")
+    private String password;
+
+    @Bean("jasyptStringEncryptor")
+    public StringEncryptor stringEncryptor() {
+        PooledPBEStringEncryptor encryptor = new PooledPBEStringEncryptor();
+        SimpleStringPBEConfig config = new SimpleStringPBEConfig();
+        config.setPassword(password);
+        config.setAlgorithm("PBEWithMD5AndDES");
+        config.setKeyObtentionIterations("1000");
+        config.setPoolSize("1");
+        config.setProviderName("SunJCE");
+        config.setSaltGeneratorClassName("org.jasypt.salt.RandomSaltGenerator");
+        config.setIvGeneratorClassName("org.jasypt.iv.NoIvGenerator");
+        config.setStringOutputType("base64");
+        encryptor.setConfig(config);
+        return encryptor;
+    }
+}

--- a/src/main/java/com/movienerds/movieinfo/JasyptConfig.java
+++ b/src/main/java/com/movienerds/movieinfo/JasyptConfig.java
@@ -11,7 +11,7 @@ import org.springframework.context.annotation.Configuration;
 public class JasyptConfig {
 
     @Value("${jasypt.encryptor.password}")
-    private String password;
+    private String password; 
 
     @Bean("jasyptStringEncryptor")
     public StringEncryptor stringEncryptor() {

--- a/src/main/java/com/movienerds/movieinfo/JasyptConfig.java
+++ b/src/main/java/com/movienerds/movieinfo/JasyptConfig.java
@@ -11,7 +11,7 @@ import org.springframework.context.annotation.Configuration;
 public class JasyptConfig {
 
     @Value("${jasypt.encryptor.password}")
-    private String password; 
+    private String password;
 
     @Bean("jasyptStringEncryptor")
     public StringEncryptor stringEncryptor() {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,9 @@
-
-
 logging.level.movienerds = debug
+
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=jdbc:mysql://movienerdsdb.cbe2cc7i5rn7.ap-northeast-2.rds.amazonaws.com:3306
+spring.datasource.username=admin
+spring.datasource.password=password
 
 api.key=7e0374f3bf216e5ade304eddf8dbf9fd
 url.starts=https://api.themoviedb.org/3/movie/

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,8 +2,8 @@ logging.level.movienerds = debug
 
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.url=jdbc:mysql://movienerdsdb.cbe2cc7i5rn7.ap-northeast-2.rds.amazonaws.com:3306
-spring.datasource.username=admin
-spring.datasource.password=ENC(5cPayj9BClJAoHjtK7CVRzfP/IpI6W4V)
+spring.datasource.username=${db.username}
+spring.datasource.password=${db.password}
 
 api.key=7e0374f3bf216e5ade304eddf8dbf9fd
 url.starts=https://api.themoviedb.org/3/movie/

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,7 +3,7 @@ logging.level.movienerds = debug
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.url=jdbc:mysql://movienerdsdb.cbe2cc7i5rn7.ap-northeast-2.rds.amazonaws.com:3306
 spring.datasource.username=admin
-spring.datasource.password=password
+spring.datasource.password=ENC(5cPayj9BClJAoHjtK7CVRzfP/IpI6W4V)
 
 api.key=7e0374f3bf216e5ade304eddf8dbf9fd
 url.starts=https://api.themoviedb.org/3/movie/


### PR DESCRIPTION
- Reviewer: @justinjeong5 

- Summary to PR

## [ RDB over NoSQL ]
- 현재는 3 가지 기능(List, Popular, Detail)만 계획 중이나, 추후 확장 가능성을 생각해보면 사용 중인 movie api처럼 RDB 스타일로 데이터를 제공받아 caching 의 역할을 하는 것이 효율적이라 생각했습니다.

## [ AWS RDS over DB on EC2 ]
- DB on EC2는 이미 사용해본 방식과 유사하기도 하고, 이미 경험해보았듯 free tier EC2의 RAM으로는 WAS build 시 memory가 부족한 경우가 있습니다.
- 필요성이 조금이라도 존재한다면 시도하는게 이 프로젝트의 의의라 생각했고, memory 부족으로 build 때 마다 mysql을 껏다켜는 것이 비효율적이며, 가능하다면 WAS가 존재하는 local 환경과 DB를 분리하는 것이 애플리케이션 운용에 안정적이라 판단했습니다.

## [ Jasypt Library ]
- SpringBoot에 DB를 연동하다보니, DB의 비밀번호가 application.properties에 그대로 노출되었습니다. 
- Jasypt library를 이용하면 프로젝트 내의 자바 클래스에서도 encrypt가 가능합니다. 그러나 위 프로젝트는 github에 노출되기에 여전히 그 클래스 내에 비밀번호가 노출되는 것이 편치 않았고, library를 통해 build되는 시점에 decryption 할 수 있는 방안으로 환경설정 파일을 수정했습니다.

     





## CheckList

- [ ] Unit test coverage
- [ ] Documentation
- [X] Self reviewed
